### PR TITLE
Release GIL when calling SyncMultiFrameListener::waitForNewFrame()

### DIFF
--- a/pylibfreenect2/libfreenect2.pyx
+++ b/pylibfreenect2/libfreenect2.pyx
@@ -613,7 +613,8 @@ cdef class SyncMultiFrameListener(FrameListener):
         """
         if frame_map is None:
             frame_map = FrameMap(take_ownership=False)
-        self.ptr.waitForNewFrame(frame_map.internal_frame_map)
+        with nogil:
+            self.ptr.waitForNewFrame(frame_map.internal_frame_map)
         return frame_map
 
 

--- a/pylibfreenect2/libfreenect2/libfreenect2.pxd
+++ b/pylibfreenect2/libfreenect2/libfreenect2.pxd
@@ -38,7 +38,7 @@ cdef extern from "libfreenect2/frame_listener_impl.h" namespace "libfreenect2":
         SyncMultiFrameListener(unsigned int)
 
         bool hasNewFrame()
-        void waitForNewFrame(map[LibFreenect2FrameType, Frame*]&)
+        void waitForNewFrame(map[LibFreenect2FrameType, Frame*]&) nogil
         void release(map[LibFreenect2FrameType, Frame*]&)
 
 cdef extern from "libfreenect2/libfreenect2.hpp" namespace "libfreenect2":


### PR DESCRIPTION
This will let other threads execute python code while calling/blocking in waitForNewFrame().

As far as I can tell, this should be safe since waitForNewFrame() doesn't interact with the python interpreter in any way.