### PR TITLE
Added timeout option to waitForNewFrame.

### DIFF
--- a/pylibfreenect2/libfreenect2/libfreenect2.pxd
+++ b/pylibfreenect2/libfreenect2/libfreenect2.pxd
@@ -39,6 +39,7 @@ cdef extern from "libfreenect2/frame_listener_impl.h" namespace "libfreenect2":
 
         bool hasNewFrame()
         void waitForNewFrame(map[LibFreenect2FrameType, Frame*]&) nogil
+        bool waitForNewFrame(map[LibFreenect2FrameType, Frame*]&, int milliseconds) nogil
         void release(map[LibFreenect2FrameType, Frame*]&)
 
 cdef extern from "libfreenect2/libfreenect2.hpp" namespace "libfreenect2":


### PR DESCRIPTION
Added a millisecond timeout option to SyncMultiFrameListener.waitForNewFrame. If set, it passes the int millisecond parameter to the C library and handles the result accordingly.

resolves #46